### PR TITLE
Connects single downloads to download manager

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,22 @@ function download(downloadsArray, callback) {
     Promise.all(downloadsArray.map(Task.async(function*(value, index, array) {
         let finalDest = yield getValidFilename(downloadFolder, value.filename, 0);
         console.log(`Downloading ${value.downloadPath} to ${finalDest}.`);
-        yield Downloads.fetch(value.downloadPath, finalDest);
+        if (!callback) {
+            // its likely a single download, so lets show it in download manager, otherwise i wont know when its done
+    		var list = yield Downloads.getList(Downloads.ALL);
+    		var download = yield Downloads.createDownload({
+    			source: value.downloadPath,
+    			target: finalDest
+    		});
+    		list.add(download);
+    		try {
+    			yield download.start();
+    		} finally {
+    			yield download.finalize(true);
+    		}
+        } else {
+            yield Downloads.fetch(value.downloadPath, finalDest);
+        }
         console.log(`${finalDest} has been downloaded`);
         return finalDest;
     }))).then(function(files) {


### PR DESCRIPTION
If do single downloads, it didn't used to prompt you when done. Now it does. And it also show in the download manager for easy access like to launch folder.
